### PR TITLE
Update build-script (#6)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,9 +4,31 @@
 name: build-release
 
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      name:
+        required: true
+        type: string
+        default: 'Korean Patch '
+        description: '퍼블리싱 제목: `Korean Patch 1.7.0`과 같은 형태로 작성'
+      version:
+        required: true
+        type: string
+        default: 'mc'
+        description: '퍼블리싱 버전: `mc1.21-1.7.0`과 같은 형태로 작성'
+      version-type:
+        required: true
+        type: choice
+        default: 'release'
+        options:
+          - release
+          - beta
+          - alpha
+        description: '퍼블리싱 버전 타입'
+      changelog:
+        required: true
+        type: string
+        description: '변경 기록: 여러 줄을 입력하려면 `\\n`을 사용 (markdown 지원)'
 
 jobs:
   build:
@@ -44,7 +66,10 @@ jobs:
           modrinth-id: qyulnpBL
           curseforge-id: 657742
           modrinth-featured: false
-          version-type: release
+          name: ${{ inputs.name }} for Forge
+          version: ${{ inputs.version }}-forge
+          changelog: ${{ inputs.changelog }}
+          version-type: ${{ inputs.version-type }}
           loaders: forge
 
       - name: Upload artifacts to Modrinth/CurseForge and GitHub for NeoForge
@@ -57,7 +82,10 @@ jobs:
           modrinth-id: qyulnpBL
           curseforge-id: 657742
           modrinth-featured: false
-          version-type: release
+          name: ${{ inputs.name }} for NeoForge
+          version: ${{ inputs.version }}-neoforge
+          changelog: ${{ inputs.changelog }}
+          version-type: ${{ inputs.version-type }}
           loaders: neoforge
 
       - name: Upload artifacts to Modrinth/CurseForge and GitHub for Fabric & Quilt
@@ -70,5 +98,8 @@ jobs:
           modrinth-id: qyulnpBL
           curseforge-id: 657742
           modrinth-featured: false
-          version-type: release
+          name: ${{ inputs.name }} for Fabric
+          version: ${{ inputs.version }}-fabric
+          changelog: ${{ inputs.changelog }}
+          version-type: ${{ inputs.version-type }}
           loaders: fabric quilt

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,8 +9,8 @@ on:
       name:
         required: true
         type: string
-        default: 'Korean Patch '
-        description: '퍼블리싱 제목: `Korean Patch 1.7.0`과 같은 형태로 작성'
+        default: 'Korean Chat Patch '
+        description: '퍼블리싱 제목: `Korean Chat Patch 1.7.0`과 같은 형태로 작성'
       version:
         required: true
         type: string
@@ -26,7 +26,7 @@ on:
           - alpha
         description: '퍼블리싱 버전 타입'
       changelog:
-        required: true
+        required: false
         type: string
         description: '변경 기록: 여러 줄을 입력하려면 `\\n`을 사용 (markdown 지원)'
 


### PR DESCRIPTION
인풋을 사용하여, 버전 작업을 더 편하게 할 수 있게 바꿔두었습니다.

이로 인해 `mc1.21-1.7.0`과 같은 버전 정보도 사용할 수 있게 되었습니다.

그리고 changelog를 일단은 입력할 수 있게 해 두었는데, 파일을 사용하여 적용할 수도 있습니다. (CHANGELOG.md)

![image](https://github.com/user-attachments/assets/2fc28cd6-2539-4458-b57b-673686d91189)


추가로 버전 range를 추가하면 좋을 것 같은데 이를 사용하려면, 음... string을 array로 바꾸는 작업이 필요해 보이더라고요.

약간 고민이 되는 부분이네요...

```yaml
on:
  workflow_dispatch:
    inputs:
      version-range:
        required: false
        type: string
        description: 'MC 버전: array를 사용하여 `>=1.21 <1.22, [1.21,1.22), 1.21`과 같이 작성'

jobs:
  build:
    runs-on: ubuntu-latest

    steps:
      - name: mc version to array
        # array 변환 작업

      # https://github.com/Kir-Antipov/mc-publish
      - name: Upload artifacts to Modrinth/CurseForge and GitHub for Forge
        uses: Kir-Antipov/mc-publish@v3.3
        with:
          game-versions: ${{ inputs.version-range }}
```