### PR TITLE
Change config file from json to json5 and add comment anotation

### DIFF
--- a/common/src/main/java/com/hyfata/najoan/koreanpatch/data/ConfigManager.java
+++ b/common/src/main/java/com/hyfata/najoan/koreanpatch/data/ConfigManager.java
@@ -4,9 +4,10 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.hyfata.najoan.koreanpatch.client.Constants;
 import com.hyfata.najoan.koreanpatch.data.config.ModConfig;
-import com.hyfata.najoan.koreanpatch.data.gson.ColorAdapter;
-import com.hyfata.najoan.koreanpatch.data.gson.EasingFunctionsAdapter;
-import com.hyfata.najoan.koreanpatch.data.gson.OutlineTypeAdapter;
+import com.hyfata.najoan.koreanpatch.data.gson.JsonCommentProcessor;
+import com.hyfata.najoan.koreanpatch.data.gson.adapter.ColorAdapter;
+import com.hyfata.najoan.koreanpatch.data.gson.adapter.EasingFunctionsAdapter;
+import com.hyfata.najoan.koreanpatch.data.gson.adapter.OutlineTypeAdapter;
 import com.hyfata.najoan.koreanpatch.data.provider.EasingFunctions;
 import com.hyfata.najoan.koreanpatch.data.provider.OutlineType;
 import net.minecraft.client.Minecraft;
@@ -19,7 +20,7 @@ import java.io.IOException;
 
 public class ConfigManager {
     private static ModConfig config = new ModConfig();
-    private static final String CONFIG_FILE_NAME = Constants.MOD_ID + ".json";
+    private static final String CONFIG_FILE_NAME = Constants.MOD_ID + ".json5";
     private static File CONFIG_FILE;
 
     private static Gson createGson() {
@@ -42,9 +43,9 @@ public class ConfigManager {
     }
 
     private static void loadFromFile() {
-        Gson gson = createGson();
         try (FileReader reader = new FileReader(CONFIG_FILE)) {
-            config = gson.fromJson(reader, ModConfig.class);
+            JsonCommentProcessor processor = new JsonCommentProcessor(createGson());
+            config = processor.readRemovingComments(reader, ModConfig.class);
         } catch (IOException e) {
             Constants.LOG.error("Failed to read config file: {}", CONFIG_FILE.toString(), e);
         }
@@ -57,9 +58,9 @@ public class ConfigManager {
     public static boolean saveConfig(ModConfig config) {
         ConfigManager.config = config;
 
-        Gson gson = createGson();
         try (FileWriter writer = new FileWriter(CONFIG_FILE)) {
-            gson.toJson(config, writer);
+            JsonCommentProcessor commentedWriter = new JsonCommentProcessor(createGson());
+            commentedWriter.writeWithComments(config, writer);
         } catch (IOException e) {
             Constants.LOG.error("Failed to write config file: {}", CONFIG_FILE.toString(), e);
             return false;

--- a/common/src/main/java/com/hyfata/najoan/koreanpatch/data/config/category/indicator/IndicatorAnimationConfig.java
+++ b/common/src/main/java/com/hyfata/najoan/koreanpatch/data/config/category/indicator/IndicatorAnimationConfig.java
@@ -1,9 +1,11 @@
 package com.hyfata.najoan.koreanpatch.data.config.category.indicator;
 
+import com.hyfata.najoan.koreanpatch.data.gson.JsonComment;
 import com.hyfata.najoan.koreanpatch.data.provider.EasingFunctions;
 
 public class IndicatorAnimationConfig {
     boolean showAnimation = true;
+    @JsonComment(value = "Easing function: ", enums = true)
     EasingFunctions easingFunction = EasingFunctions.EASE_OUT_QUINT;
     int speed = 30;
 

--- a/common/src/main/java/com/hyfata/najoan/koreanpatch/data/config/category/indicator/outline/OutlineConfig.java
+++ b/common/src/main/java/com/hyfata/najoan/koreanpatch/data/config/category/indicator/outline/OutlineConfig.java
@@ -1,9 +1,11 @@
 package com.hyfata.najoan.koreanpatch.data.config.category.indicator.outline;
 
+import com.hyfata.najoan.koreanpatch.data.gson.JsonComment;
 import com.hyfata.najoan.koreanpatch.data.provider.OutlineType;
 
 public class OutlineConfig {
     boolean showOutline = true;
+    @JsonComment(value = "Outline type: ", enums = true)
     OutlineType outlineType = OutlineType.CIRCLE;
     OutlineColorConfig colorOpacity = new OutlineColorConfig();
 

--- a/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/JsonComment.java
+++ b/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/JsonComment.java
@@ -1,0 +1,13 @@
+package com.hyfata.najoan.koreanpatch.data.gson;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface JsonComment {
+    String value() default "";
+    boolean enums() default false;
+}

--- a/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/JsonCommentProcessor.java
+++ b/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/JsonCommentProcessor.java
@@ -1,0 +1,121 @@
+package com.hyfata.najoan.koreanpatch.data.gson;
+
+import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class JsonCommentProcessor {
+    private final Gson gson;
+
+    public JsonCommentProcessor(Gson gson) {
+        this.gson = gson;
+    }
+
+    public void writeWithComments(Object obj, Writer writer) throws IOException {
+        writeObject(obj, writer, 0, new IdentityHashMap<>());
+    }
+
+    public <T> T readRemovingComments(Reader reader, Class<T> type) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        int ch;
+        while ((ch = reader.read()) != -1) {
+            builder.append((char) ch);
+        }
+        String cleaned = stripComments(builder.toString());
+        return gson.fromJson(cleaned, type);
+    }
+
+    public static String stripComments(String json) {
+        json = json.replaceAll("(?m)^\\s*//.*?$", "");
+        json = json.replaceAll("(?s)/\\*.*?\\*/", "");
+        return json;
+    }
+
+    private void writeObject(Object obj, Writer writer, int indent, Map<Object, Boolean> visited) throws IOException {
+        if (obj == null) {
+            writer.write("null");
+            return;
+        }
+
+        if (isPrimitive(obj) || obj.getClass().isEnum() || isJavaClass(obj.getClass())) {
+            gson.toJson(obj, writer);
+            return;
+        }
+
+        if (visited.containsKey(obj)) {
+            writer.write("\"<circular>\"");
+            return;
+        }
+        visited.put(obj, true);
+
+        Field[] fields = obj.getClass().getDeclaredFields();
+        writer.write("{\n");
+
+        for (int i = 0; i < fields.length; i++) {
+            Field field = fields[i];
+            field.setAccessible(true);
+
+            Object value;
+            try {
+                value = field.get(obj);
+            } catch (IllegalAccessException e) {
+                continue;
+            }
+
+            JsonComment comment = field.getAnnotation(JsonComment.class);
+            if (comment != null) {
+                indent(writer, indent + 1);
+
+                StringBuilder commentLine = new StringBuilder("// " + comment.value());
+
+                if (comment.enums() && field.getType().isEnum()) {
+                    Object[] enumConstants = field.getType().getEnumConstants();
+                    if (enumConstants != null) {
+                        String enumList = Arrays.stream(enumConstants)
+                                .map(Object::toString)
+                                .collect(Collectors.joining(", "));
+                        commentLine.append("[").append(enumList).append("]");
+                    }
+                }
+
+                writer.write(commentLine.toString() + "\n");
+            }
+
+            indent(writer, indent + 1);
+            writer.write("\"" + field.getName() + "\": ");
+            writeObject(value, writer, indent + 1, visited);
+
+            if (i < fields.length - 1) {
+                writer.write(",");
+            }
+            writer.write("\n");
+        }
+
+        indent(writer, indent);
+        writer.write("}");
+        visited.remove(obj);
+    }
+
+    private boolean isPrimitive(Object value) {
+        if (value == null) return true;
+        Class<?> c = value.getClass();
+        return c.isPrimitive() || c == String.class || Number.class.isAssignableFrom(c) || Boolean.class.isAssignableFrom(c);
+    }
+
+    private boolean isJavaClass(Class<?> clazz) {
+        return clazz.getPackage() != null && clazz.getPackage().getName().startsWith("java");
+    }
+
+    private void indent(Writer writer, int indent) throws IOException {
+        for (int i = 0; i < indent; i++) {
+            writer.write("  ");
+        }
+    }
+}

--- a/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/adapter/ColorAdapter.java
+++ b/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/adapter/ColorAdapter.java
@@ -1,4 +1,4 @@
-package com.hyfata.najoan.koreanpatch.data.gson;
+package com.hyfata.najoan.koreanpatch.data.gson.adapter;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;

--- a/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/adapter/EasingFunctionsAdapter.java
+++ b/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/adapter/EasingFunctionsAdapter.java
@@ -1,4 +1,4 @@
-package com.hyfata.najoan.koreanpatch.data.gson;
+package com.hyfata.najoan.koreanpatch.data.gson.adapter;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;

--- a/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/adapter/OutlineTypeAdapter.java
+++ b/common/src/main/java/com/hyfata/najoan/koreanpatch/data/gson/adapter/OutlineTypeAdapter.java
@@ -1,4 +1,4 @@
-package com.hyfata.najoan.koreanpatch.data.gson;
+package com.hyfata.najoan.koreanpatch.data.gson.adapter;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;


### PR DESCRIPTION
이건 머지해도 되고, 머지 안 해도 되는 기능입니다.

json을 json5로 설정하여 주석도 들어가게 설정하였고, 파싱을 새로 만들어서 읽을 때는 주석 제거해서 읽도록 했습니다.

anotation `@JsonComment(String value)` or `@JsonComment(String value, boolean enums)`를 사용할 수 있고,

전자는 `// ...`로 된 주석 추가, 후자는 enums = true이고 필드 타입이 Enum일 때, Enum의 필드를 `[A, B, C]`로 value 뒤에 넣는 기능을 합니다.

![image](https://github.com/user-attachments/assets/8e0bdab2-054d-4fed-b2f3-5c662e5cfd4f)

![image](https://github.com/user-attachments/assets/55c5671f-2714-4ab7-a88b-e617544df844)
